### PR TITLE
Fix Atlas Cities compatibility

### DIFF
--- a/TLM/TLM/LoadingExtension.cs
+++ b/TLM/TLM/LoadingExtension.cs
@@ -263,8 +263,12 @@ namespace TrafficManager {
 				if (loadingExtensions != null) {
 					Log.Message("Loaded extensions:");
 					foreach (ILoadingExtension extension in loadingExtensions) {
+						var extensionStr = extension.ToString();
+						if ("HeightMapExtension".Equals(extensionStr) || "contourExtension".Equals(extensionStr)) continue;
+
 						Log.Message($"type: {extension.GetType().ToString()} type namespace: {extension.GetType().Namespace.ToString()} toString: {extension.ToString()}");
 						var namespaceStr = extension.GetType().Namespace.ToString();
+
 						if ("Improved_AI".Equals(namespaceStr)) {
 							IsImprovedAiLoaded = true;
 							IsPathManagerCompatible = false; // Improved AI found


### PR DESCRIPTION
Fixes the issue that the LoadingExtension of Atlas Cities is not in a
namespace (causing a No Reference error), which would break TLM. Filters
out the Atlas Cities specific extensions when iteration over
loadingExtensions.