### PR TITLE
Fix Typos in TrafficPriorityManager caused by UTF-8 symbols.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 /logo/
+
+# MSVS 2017 artifacts
+/.vs/slnx.sqlite

--- a/TLM/TLM/Custom/AI/CustomVehicleAI.cs
+++ b/TLM/TLM/Custom/AI/CustomVehicleAI.cs
@@ -454,7 +454,7 @@ namespace TrafficManager.Custom.AI {
 #endif
 											vehicleState.JunctionTransitState = VehicleJunctionTransitState.Stop;
 
-											if (sqrSpeed <= TrafficPriorityManager.MAX_SQR_YÌELD_VELOCITY || Options.simAccuracy <= 2) {
+											if (sqrSpeed <= TrafficPriorityManager.MAX_SQR_YIELD_VELOCITY || Options.simAccuracy <= 2) {
 												if (Options.simAccuracy >= 4) {
 													vehicleState.JunctionTransitState = VehicleJunctionTransitState.Leave;
 												} else {
@@ -482,7 +482,7 @@ namespace TrafficManager.Custom.AI {
 #endif
 
 												// vehicle has not yet reached yield speed
-												maxSpeed = TrafficPriorityManager.MAX_YÌELD_VELOCITY;
+												maxSpeed = TrafficPriorityManager.MAX_YIELD_VELOCITY;
 												return false;
 											}
 										} else {

--- a/TLM/TLM/Manager/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/TrafficPriorityManager.cs
@@ -19,8 +19,8 @@ namespace TrafficManager.Manager {
 		}
 
 		public const float MAX_SQR_STOP_VELOCITY = 0.01f;
-		public const float MAX_SQR_YÌELD_VELOCITY = 0.09f;
-		public const float MAX_YÌELD_VELOCITY = 0.3f;
+		public const float MAX_SQR_YIELD_VELOCITY = 0.09f;
+		public const float MAX_YIELD_VELOCITY = 0.3f;
 
 		/// <summary>
 		/// List of segments that are connected to roads with timed traffic lights or priority signs. Index: segment id

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -98,9 +98,6 @@
     <Compile Include="Custom\Manager\CustomNetManager.cs" />
     <Compile Include="Custom\Manager\CustomCitizenManager.cs" />
     <Compile Include="Custom\Manager\CustomVehicleManager.cs" />
-    <Compile Include="GameBridge\INetLaneBridge.cs" />
-    <Compile Include="GameBridge\INetNodeBridge.cs" />
-    <Compile Include="GameBridge\INetSegmentBridge.cs" />
     <Compile Include="Manager\AbstractCustomManager.cs" />
     <Compile Include="Manager\AbstractNodeGeometryObservingManager.cs" />
     <Compile Include="Manager\AbstractSegmentGeometryObservingManager.cs" />
@@ -108,7 +105,6 @@
     <Compile Include="Manager\ICustomDataManager.cs" />
     <Compile Include="Manager\LaneArrowManager.cs" />
     <Compile Include="Manager\OptionsManager.cs" />
-    <Compile Include="Manager\TemplateManager.cs" />
     <Compile Include="Manager\TrafficLightManager.cs" />
     <Compile Include="Manager\TrafficMeasurementManager.cs" />
     <Compile Include="Manager\JunctionRestrictionsManager.cs" />
@@ -126,12 +122,6 @@
     <Compile Include="Geometry\SegmentEndGeometry.cs" />
     <Compile Include="Manager\VehicleStateManager.cs" />
     <Compile Include="Manager\VehicleRestrictionsManager.cs" />
-    <Compile Include="Traffic\Template\SegmentEndRestrictionsTemplate.cs" />
-    <Compile Include="Traffic\Template\NodeTemplate.cs" />
-    <Compile Include="Traffic\Template\LaneConnectionTemplate.cs" />
-    <Compile Include="Traffic\Template\LaneTemplate.cs" />
-    <Compile Include="Traffic\Template\SegmentEndTemplate.cs" />
-    <Compile Include="Traffic\Template\SegmentEndLightsTemplate.cs" />
     <Compile Include="Traffic\VehicleJunctionTransitState.cs" />
     <Compile Include="State\Configuration.cs" />
     <Compile Include="Custom\AI\CustomCarAI.cs" />


### PR DESCRIPTION
For some reason symbols " Ì " in definition of constants in TrafficPriorityManager and symbols " Ì " in CustomVehicleAI.cs are UTF-8 non identical that makes MSVS 2017 RC raise error. 
This commit changes the letter to more traditional English variant " I "
Also i made some cleanup of files absent in repo.