### PR TITLE
Make vehicle restriction path cost configurable

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -2345,9 +2345,9 @@ namespace TrafficManager.Custom.PathFinding {
 			if (strictlyAvoidLane) {
 #if DEBUGPF
 					if (debug)
-						logBuf.Add($"ProcessItemCosts: applying strict lane avoidance on deactivated advaned AI");
+						logBuf.Add($"ProcessItemCosts: applying strict lane avoidance penalty");
 #endif
-				prevCost *= 10000f;
+				prevCost *= _conf.RestrictedVehicleTypeOnLanePenalty;
 			}
 
 			if (!useAdvancedAI) {

--- a/TLM/TLM/State/GlobalConfig.cs
+++ b/TLM/TLM/State/GlobalConfig.cs
@@ -14,7 +14,7 @@ namespace TrafficManager.State {
 	public class GlobalConfig {
 		public const string FILENAME = "TMPE_GlobalConfig.xml";
 		public const string BACKUP_FILENAME = FILENAME + ".bak";
-		private static int LATEST_VERSION = 5;
+		private static int LATEST_VERSION = 6;
 #if DEBUG
 		private static uint lastModificationCheckFrame = 0;
 #endif
@@ -148,6 +148,11 @@ namespace TrafficManager.State {
 		/// maximum penalty for heavy vehicles driving on an inner lane (in %)
 		/// </summary>
 		public float HeavyVehicleMaxInnerLanePenalty = 40f;
+
+		/// <summary>
+		/// penalty for a vehicle type that is restricted on the lane (path cost multiplier)
+		/// </summary>
+		public float RestrictedVehicleTypeOnLanePenalty = 10000f;
 
 
 		/// <summary>


### PR DESCRIPTION
(also removed "on deactivated advaned AI" because that debug message part was wrong)