### PR TITLE
Fix citizens abandoning their cars in strange places

### DIFF
--- a/TLM/TLM/Custom/AI/CustomCarAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCarAI.cs
@@ -444,7 +444,7 @@ namespace TrafficManager.Custom.AI {
 		public bool CustomStartPathFind(ushort vehicleID, ref Vehicle vehicleData, Vector3 startPos, Vector3 endPos, bool startBothWays, bool endBothWays, bool undergroundTarget) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[2])
-				Log.Warning($"CustomCarAI.CustomStartPathFind({vehicleID}): called for vehicle {vehicleID}, startPos={startPos}, endPos={endPos}, startBothWays={startBothWays}, endBothWays={endBothWays}, undergroundTarget={undergroundTarget}");
+				Log.Warning($"CustomCarAI.CustomStartPathFind({vehicleID}): VehicleID={vehicleID}, startPos={startPos}, endPos={endPos}, startBothWays={startBothWays}, endBothWays={endBothWays}, undergroundTarget={undergroundTarget}");
 #endif
 
 			ExtVehicleType vehicleType = ExtVehicleType.None;

--- a/TLM/TLM/Custom/AI/CustomCitizenAI.cs
+++ b/TLM/TLM/Custom/AI/CustomCitizenAI.cs
@@ -27,7 +27,7 @@ namespace TrafficManager.Custom.AI {
 		public bool ExtStartPathFind(ushort instanceID, ref CitizenInstance citizenData, ref ExtCitizenInstance extInstance, Vector3 startPos, Vector3 endPos, VehicleInfo vehicleInfo) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[2])
-				Log.Warning($"CustomCitizenAI.ExtStartPathFind({instanceID}): called for citizen instance {instanceID}, citizen {citizenData.m_citizen}, startPos={startPos}, endPos={endPos}, sourceBuilding={citizenData.m_sourceBuilding}, targetBuilding={citizenData.m_targetBuilding}, pathMode={extInstance.pathMode}");
+				Log.Warning($"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance {instanceID}, citizen {citizenData.m_citizen}, startPos={startPos}, endPos={endPos}, sourceBuilding={citizenData.m_sourceBuilding}, targetBuilding={citizenData.m_targetBuilding}, pathMode={extInstance.pathMode}");
 #endif
 
 			// NON-STOCK CODE START
@@ -48,7 +48,7 @@ namespace TrafficManager.Custom.AI {
 						case ExtPathMode.ApproachingParkedCar:
 #if DEBUG
 							if (GlobalConfig.Instance.Debug.Switches[2])
-								Log._Debug($"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance {instanceID} has CurrentPathMode={extInstance.pathMode}. Switching to 'CalculatingWalkingPathToParkedCar'.");
+								Log._Debug($"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance {instanceID} has CurrentPathMode={extInstance.pathMode}. Change to 'CalculatingWalkingPathToParkedCar'.");
 #endif
 							extInstance.pathMode = ExtPathMode.CalculatingWalkingPathToParkedCar;
 							break;
@@ -70,7 +70,7 @@ namespace TrafficManager.Custom.AI {
 						case ExtPathMode.CalculatingCarPathToTarget:
 #if DEBUG
 							if (GlobalConfig.Instance.Debug.Switches[2])
-								Log._Debug($"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance {instanceID} has CurrentPathMode={extInstance.pathMode}.  Change to 'RequiresCarPath'.");
+								Log._Debug($"CustomCitizenAI.ExtStartPathFind({instanceID}): Citizen instance {instanceID} has CurrentPathMode={extInstance.pathMode}. Change to 'RequiresCarPath'.");
 #endif
 							extInstance.pathMode = ExtPathMode.RequiresCarPath;
 							break;

--- a/TLM/TLM/Custom/AI/CustomHumanAI.cs
+++ b/TLM/TLM/Custom/AI/CustomHumanAI.cs
@@ -43,7 +43,7 @@ namespace TrafficManager.Custom.AI {
 
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[2])
-					Log._Debug($"CustomHumanAI.CustomSimulationStep({instanceID}): Path: {instanceData.m_path}, mainPathState={mainPathState}");
+					Log._Debug($"CustomHumanAI.CustomSimulationStep({instanceID}): Path={instanceData.m_path}, mainPathState={mainPathState}");
 #endif
 
 				ExtSoftPathState finalPathState = ExtSoftPathState.None;
@@ -55,7 +55,7 @@ namespace TrafficManager.Custom.AI {
 						finalPathState = AdvancedParkingManager.Instance.UpdateCitizenPathState(instanceID, ref instanceData, ref ExtCitizenInstanceManager.Instance.ExtInstances[instanceID], ref Singleton<CitizenManager>.instance.m_citizens.m_buffer[instanceData.m_citizen], mainPathState);
 #if DEBUG
 						if (GlobalConfig.Instance.Debug.Switches[2])
-							Log._Debug($"CustomHumanAI.CustomSimulationStep({instanceID}): Applied Parking AI logic. Path: {instanceData.m_path}, mainPathState={mainPathState}, finalPathState={finalPathState}, extCitizenInstance={ExtCitizenInstanceManager.Instance.ExtInstances[instanceID]}");
+							Log._Debug($"CustomHumanAI.CustomSimulationStep({instanceID}): Applied Parking AI logic. Path={instanceData.m_path}, mainPathState={mainPathState}, finalPathState={finalPathState}, extCitizenInstance={ExtCitizenInstanceManager.Instance.ExtInstances[instanceID]}");
 #endif
 					}
 #if BENCHMARK
@@ -162,7 +162,7 @@ namespace TrafficManager.Custom.AI {
 					// citizen is reaching their parked car but does not own a parked car
 #if DEBUG
 						if (GlobalConfig.Instance.Debug.Switches[2])
-							Log.Warning($"CustomHumanAI.CustomSimulationStep({instanceID}): Citizen instance {instanceID} was walking to / reaching their parked car ({extInstance.pathMode}) but parked car has disappeared. RESET.");
+							Log.Warning($"CustomHumanAI.ExtSimulationStep({instanceID}): Citizen instance {instanceID} was walking to / reaching their parked car ({extInstance.pathMode}) but parked car has disappeared. RESET.");
 #endif
 
 					extInstance.Reset();
@@ -200,7 +200,7 @@ namespace TrafficManager.Custom.AI {
 						case ParkedCarApproachState.Failure:
 #if DEBUG
 								if (GlobalConfig.Instance.Debug.Switches[2])
-									Log._Debug($"CustomHumanAI.CustomSimulationStep({instanceID}): Citizen instance {instanceID} failed to arrive at parked car. PathMode={extInstance.pathMode}");
+									Log._Debug($"CustomHumanAI.ExtSimulationStep({instanceID}): Citizen instance {instanceID} failed to arrive at parked car. PathMode={extInstance.pathMode}");
 #endif
 							// repeat path-finding
 							instanceData.m_flags &= ~CitizenInstance.Flags.WaitingPath;
@@ -230,7 +230,7 @@ namespace TrafficManager.Custom.AI {
 		public static bool EnterParkedCar(ushort instanceID, ref CitizenInstance instanceData, ushort parkedVehicleId, out ushort vehicleId) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[2])
-				Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}, ..., {parkedVehicleId}) called.");
+				Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): parkedVehicleId={parkedVehicleId})");
 #endif
 			VehicleManager vehManager = Singleton<VehicleManager>.instance;
 			NetManager netManager = Singleton<NetManager>.instance;
@@ -244,7 +244,7 @@ namespace TrafficManager.Custom.AI {
 			if (! CustomPathManager._instance.m_pathUnits.m_buffer[instanceData.m_path].GetPosition(0, out vehLanePathPos)) {
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[2])
-					Log._Debug($"CustomHumanAI.EnterParkedCar: Could not get first car path position of citizen instance {instanceID}!");
+					Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): Could not get first car path position of citizen instance {instanceID}!");
 #endif
 
 				vehicleId = 0;
@@ -253,7 +253,7 @@ namespace TrafficManager.Custom.AI {
 			uint vehLaneId = PathManager.GetLaneID(vehLanePathPos);
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[4])
-				Log._Debug($"CustomHumanAI.EnterParkedCar: Determined vehicle position for citizen instance {instanceID}: seg. {vehLanePathPos.m_segment}, lane {vehLanePathPos.m_lane}, off {vehLanePathPos.m_offset} (lane id {vehLaneId})");
+				Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): Determined vehicle position for citizen instance {instanceID}: seg. {vehLanePathPos.m_segment}, lane {vehLanePathPos.m_lane}, off {vehLanePathPos.m_offset} (lane id {vehLaneId})");
 #endif
 
 			Vector3 vehLanePos;
@@ -287,7 +287,7 @@ namespace TrafficManager.Custom.AI {
 				if (! vehicleInfo.m_vehicleAI.TrySpawn(vehicleId, ref vehManager.m_vehicles.m_buffer[vehicleId])) {
 #if DEBUG
 					if (GlobalConfig.Instance.Debug.Switches[2])
-						Log._Debug($"CustomHumanAI.EnterParkedCar: Could not spawn a {vehicleInfo.m_vehicleType} for citizen instance {instanceID}!");
+						Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): Could not spawn a {vehicleInfo.m_vehicleType} for citizen instance {instanceID}!");
 #endif
 					return false;
 				}
@@ -316,7 +316,7 @@ namespace TrafficManager.Custom.AI {
 
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[4])
-					Log._Debug($"CustomHumanAI.EnterParkedCar: Citizen instance {instanceID} is now entering vehicle {vehicleId}. Set vehicle target position to {vehLanePos} (segment={vehLanePathPos.m_segment}, lane={vehLanePathPos.m_lane}, offset={vehLanePathPos.m_offset})");
+					Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): Citizen instance {instanceID} is now entering vehicle {vehicleId}. Set vehicle target position to {vehLanePos} (segment={vehLanePathPos.m_segment}, lane={vehLanePathPos.m_lane}, offset={vehLanePathPos.m_offset})");
 #endif
 
 				return true;
@@ -324,7 +324,7 @@ namespace TrafficManager.Custom.AI {
 				// failed to find a road position
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[2])
-					Log._Debug($"CustomHumanAI.EnterParkedCar: Could not find a road position for citizen instance {instanceID} near parked vehicle {parkedVehicleId}!");
+					Log._Debug($"CustomHumanAI.EnterParkedCar({instanceID}): Could not find a road position for citizen instance {instanceID} near parked vehicle {parkedVehicleId}!");
 #endif
 				return false;
 			}

--- a/TLM/TLM/Custom/AI/CustomResidentAI.cs
+++ b/TLM/TLM/Custom/AI/CustomResidentAI.cs
@@ -52,7 +52,7 @@ namespace TrafficManager.Custom.AI {
 							target = InstanceID.Empty;
 							return Locale.Get("CITIZEN_STATUS_DRIVINGTO_OUTSIDE");
 						}
-						
+
 						if (targetBuilding == homeId) {
 							target = InstanceID.Empty;
 							return Locale.Get("CITIZEN_STATUS_DRIVINGTO_HOME");
@@ -198,7 +198,7 @@ namespace TrafficManager.Custom.AI {
 					if (parkedVehicleId != 0) {
 #if DEBUG
 						if (GlobalConfig.Instance.Debug.Switches[2])
-							Log._Debug($"CustomResidentAI.GetVehicleInfo: Citizen instance {instanceID} owns a parked vehicle {parkedVehicleId}. Reusing vehicle info.");
+							Log._Debug($"CustomResidentAI.CustomGetVehicleInfo({instanceID}): Citizen instance {instanceID} owns a parked vehicle {parkedVehicleId}. Reusing vehicle info.");
 #endif
 						carInfo = Singleton<VehicleManager>.instance.m_parkedVehicles.m_buffer[parkedVehicleId].Info;
 					}
@@ -218,7 +218,7 @@ namespace TrafficManager.Custom.AI {
 					return bikeInfo;
 				}
 			}
-			
+
 			if ((useCar || useTaxi) && carInfo != null) {
 				return carInfo;
 			}

--- a/TLM/TLM/Custom/AI/CustomTouristAI.cs
+++ b/TLM/TLM/Custom/AI/CustomTouristAI.cs
@@ -151,7 +151,7 @@ namespace TrafficManager.Custom.AI {
 					if (parkedVehicleId != 0) {
 #if DEBUG
 						if (GlobalConfig.Instance.Debug.Switches[2])
-							Log._Debug($"CustomResidentAI.GetVehicleInfo: Citizen instance {instanceID} owns a parked vehicle {parkedVehicleId}. Reusing vehicle info.");
+							Log._Debug($"CustomTouristAI.CustomGetVehicleInfo({instanceID}): Citizen instance {instanceID} owns a parked vehicle {parkedVehicleId}. Reusing vehicle info.");
 #endif
 						carInfo = Singleton<VehicleManager>.instance.m_parkedVehicles.m_buffer[parkedVehicleId].Info;
 					}
@@ -159,6 +159,7 @@ namespace TrafficManager.Custom.AI {
 #if BENCHMARK
 			}
 #endif
+
 			if (carInfo == null && (useCar || useTaxi)) {
 				// NON-STOCK CODE END
 				carInfo = Singleton<VehicleManager>.instance.GetRandomVehicleInfo(ref randomizer, service, subService, ItemClass.Level.Level1);
@@ -170,6 +171,7 @@ namespace TrafficManager.Custom.AI {
 					return bikeInfo;
 				}
 			}
+
 			if ((useCar || useTaxi) && carInfo != null) {
 				return carInfo;
 			}

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -834,7 +834,7 @@ namespace TrafficManager.Manager.Impl {
 		/// <param name="instanceData">Citizen instance data</param>
 		/// <param name="extInstance">extended citizen instance information</param>
 		/// <returns>if true path-finding may be repeated (path mode has been updated), false otherwise</returns>
-		protected static ExtSoftPathState OnCitizenPathFindFailure(ushort instanceID, ref CitizenInstance instanceData, ref ExtCitizenInstance extInstance) {
+		protected ExtSoftPathState OnCitizenPathFindFailure(ushort instanceID, ref CitizenInstance instanceData, ref ExtCitizenInstance extInstance) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[2])
 				Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Path-finding failed for citizen instance {extInstance.instanceId}. CurrentPathMode={extInstance.pathMode}");
@@ -843,12 +843,7 @@ namespace TrafficManager.Manager.Impl {
 			// update demands
 			if (instanceData.m_targetBuilding != 0) {
 				switch (extInstance.pathMode) {
-					/*case ExtPathMode.CalculatingCarPathToTarget:
-					case ExtPathMode.CalculatingCarPathToKnownParkPos:
-						//ExtBuildingManager.Instance.GetExtBuilding(instanceData.m_targetBuilding).AddParkingSpaceDemand((uint)Options.debugValues[27]);
-						break;*/
 					case ExtPathMode.None:
-					case ExtPathMode.CalculatingWalkingPathToParkedCar:
 					case ExtPathMode.CalculatingWalkingPathToTarget:
 					case ExtPathMode.PublicTransportToTarget:
 					case ExtPathMode.TaxiToTarget:
@@ -859,9 +854,8 @@ namespace TrafficManager.Manager.Impl {
 								Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Increasing public transport demand of target building {instanceData.m_targetBuilding} and source building {instanceData.m_sourceBuilding}");
 #endif
 
-							if (instanceData.m_targetBuilding != 0) {
-								ExtBuildingManager.Instance.ExtBuildings[instanceData.m_targetBuilding].AddPublicTransportDemand((uint)GlobalConfig.Instance.ParkingAI.PublicTransportDemandIncrement, false);
-							}
+							ExtBuildingManager.Instance.ExtBuildings[instanceData.m_targetBuilding].AddPublicTransportDemand((uint)GlobalConfig.Instance.ParkingAI.PublicTransportDemandIncrement, false);
+
 							if (instanceData.m_sourceBuilding != 0) {
 								ExtBuildingManager.Instance.ExtBuildings[instanceData.m_sourceBuilding].AddPublicTransportDemand((uint)GlobalConfig.Instance.ParkingAI.PublicTransportDemandIncrement, true);
 							}
@@ -870,15 +864,49 @@ namespace TrafficManager.Manager.Impl {
 				}
 			}
 
-			if (extInstance.pathMode == ExtPathMode.CalculatingWalkingPathToParkedCar) {
-				// parked car is unreachable: despawn parked car
+			if (extInstance.pathMode == ExtPathMode.None || extInstance.pathMode == ExtPathMode.CalculatingWalkingPathToParkedCar) {
+				// destination is unreachable and don't have a car or car is parked near home: fail hard
+				// or parked car is abandoned: fail soft, move parked car and try again
+				// or destination is still unreachable after moving car: fail hard
+
+				// Does citizen have a parked car
 				ushort parkedVehicleId = Singleton<CitizenManager>.instance.m_citizens.m_buffer[instanceData.m_citizen].m_parkedVehicle;
 				if (parkedVehicleId != 0) {
 #if DEBUG
-					if (GlobalConfig.Instance.Debug.Switches[2])
-						Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Releasing parked vehicle {parkedVehicleId} for citizen instance {extInstance.instanceId}. CurrentPathMode={extInstance.pathMode}");
+					if (GlobalConfig.Instance.Debug.Switches[4])
+						Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Try to move parked vehicle {parkedVehicleId} for citizen instance {extInstance.instanceId}. CurrentPathMode={extInstance.pathMode}");
 #endif
-					Singleton<VehicleManager>.instance.ReleaseParkedVehicle(parkedVehicleId);
+					// Is car too far away for citizen to walk to
+					VehicleManager vehicleManager = Singleton<VehicleManager>.instance;
+					ref VehicleParked parkedVehicle = ref vehicleManager.m_parkedVehicles.m_buffer[parkedVehicleId];
+					Vector3 targetPos = instanceData.GetLastFramePosition();
+					float parkedToCitizen = (parkedVehicle.m_position - targetPos).magnitude;
+					if (parkedToCitizen > GlobalConfig.Instance.ParkingAI.MaxParkedCarDistanceToBuilding) {
+						// Is car also too far from home - abandoned
+						ushort homeId = Singleton<CitizenManager>.instance.m_citizens.m_buffer[instanceData.m_citizen].m_homeBuilding;
+						float parkedToHome = (parkedVehicle.m_position - Singleton<BuildingManager>.instance.m_buildings.m_buffer[homeId].m_position).magnitude;
+						if (parkedToHome > GlobalConfig.Instance.ParkingAI.MaxParkedCarDistanceToHome) {
+							// Try to move car to a nearby parking space
+							VehicleInfo vehicleInfo = parkedVehicle.Info;
+							ExtParkingSpaceLocation parkingSpaceLocation = 0;
+							ushort parkingSpaceLocationId = 0;
+							Vector3 parkPos = Vector3.zero;
+							Quaternion parkRot = Quaternion.identity;
+							float parkOffset = 0f;
+							if (FindParkingSpaceInVicinity(targetPos, vehicleInfo, homeId, parkedVehicleId, GlobalConfig.Instance.ParkingAI.MaxParkedCarDistanceToBuilding, out parkingSpaceLocation, out parkingSpaceLocationId, out parkPos, out parkRot, out parkOffset)) {
+								// Move car, change pathMode to allow a soft fail AND have the whole path recalculated
+								vehicleManager.RemoveFromGrid(parkedVehicleId, ref parkedVehicle);
+								parkedVehicle.m_position = parkPos;
+								parkedVehicle.m_rotation = parkRot;
+								vehicleManager.AddToGrid(parkedVehicleId, ref parkedVehicle);
+								extInstance.pathMode = ExtCitizenInstance.ExtPathMode.PublicTransportToTarget;
+#if DEBUG
+								if (GlobalConfig.Instance.Debug.Switches[4])
+									Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Moved parked vehicle {parkedVehicleId} for citizen instance {extInstance.instanceId}. CurrentPathMode={extInstance.pathMode}");
+#endif
+							}
+						}
+					}
 				}
 			}
 
@@ -894,6 +922,14 @@ namespace TrafficManager.Manager.Impl {
 						Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Path failed but it may be retried to walk to the target.");
 #endif
 					extInstance.pathMode = ExtPathMode.RequiresWalkingPathToTarget;
+					ret = ExtSoftPathState.FailedSoft;
+					break;
+				case ExtPathMode.PublicTransportToTarget:
+#if DEBUG
+					if (GlobalConfig.Instance.Debug.Switches[2])
+						Log._Debug($"AdvancedParkingManager.OnCitizenPathFindFailure({instanceID}): Path failed but it may be retried with new parked car position.");
+#endif
+					extInstance.pathMode = ExtPathMode.None;
 					ret = ExtSoftPathState.FailedSoft;
 					break;
 				default:

--- a/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
+++ b/TLM/TLM/Manager/Impl/AdvancedParkingManager.cs
@@ -51,19 +51,19 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		protected override void OnEnableFeatureInternal() {
-			
+
 		}
 
 		public ExtSoftPathState UpdateCitizenPathState(ushort citizenInstanceId, ref CitizenInstance citizenInstance, ref ExtCitizenInstance extInstance, ref Citizen citizen, ExtPathState mainPathState) {
 #if DEBUG
 			if (GlobalConfig.Instance.Debug.Switches[4])
-				Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}) called.");
+				Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}.");
 #endif
 			if (mainPathState == ExtPathState.Calculating) {
 				// main path is still calculating, do not check return path
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[4])
-					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): still calculating main path. returning CALCULATING.");
+					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. still calculating main path. returning CALCULATING.");
 #endif
 				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
@@ -74,7 +74,7 @@ namespace TrafficManager.Manager.Impl {
 				// no citizen
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[2])
-					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): no citizen found!");
+					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. no citizen found!");
 #endif
 				return ExtCitizenInstance.ConvertPathStateToSoftPathState(mainPathState);
 			}
@@ -83,7 +83,7 @@ namespace TrafficManager.Manager.Impl {
 				// main path failed or non-existing: reset return path
 #if DEBUG
 				if (GlobalConfig.Instance.Debug.Switches[2])
-					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): mainPathSate is None or Failed. Resetting instance and returning FAILED.");
+					Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. mainPathSate is None or Failed. Resetting instance and returning FAILED.");
 #endif
 
 				if (mainPathState == ExtPathState.Failed) {
@@ -106,21 +106,21 @@ namespace TrafficManager.Manager.Impl {
 					// no return path calculated: ignore
 #if DEBUG
 					if (GlobalConfig.Instance.Debug.Switches[2])
-						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): return path state is None. Ignoring and returning main path state.");
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. return path state is None. Ignoring and returning main path state.");
 #endif
 					break;
 				case ExtPathState.Calculating: // OK
 											   // return path not read yet: wait for it
 #if DEBUG
 					if (GlobalConfig.Instance.Debug.Switches[4])
-						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): return path state is still calculating.");
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. return path state is still calculating.");
 #endif
 					return ExtSoftPathState.Calculating;
 				case ExtPathState.Failed: // OK
 										  // no walking path from parking position to target found. flag main path as 'failed'.
 #if DEBUG
 					if (GlobalConfig.Instance.Debug.Switches[2])
-						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): Return path FAILED.");
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}. Return path FAILED.");
 #endif
 					success = false;
 					break;
@@ -128,7 +128,7 @@ namespace TrafficManager.Manager.Impl {
 					// handle valid return path
 #if DEBUG
 					if (GlobalConfig.Instance.Debug.Switches[4])
-						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}, ..., {mainPathState}): Path is READY.");
+						Log._Debug($"AdvancedParkingManager.UpdateCitizenPathState({citizenInstanceId}): mainPathState={mainPathState}). Path is READY.");
 #endif
 					break;
 			}
@@ -427,7 +427,7 @@ namespace TrafficManager.Manager.Impl {
 			}
 
 
-			
+
 			// check if path is complete
 			PathUnit.Position pos;
 			if (instanceData.m_pathPositionIndex != 255 && (instanceData.m_path == 0 || !CustomPathManager._instance.m_pathUnits.m_buffer[instanceData.m_path].GetPosition(instanceData.m_pathPositionIndex >> 1, out pos))) {
@@ -502,7 +502,7 @@ namespace TrafficManager.Manager.Impl {
 					 * when using public transport together with a car (assuming a "source -> walk -> drive -> walk -> use public transport -> walk -> target" path)
 					 * discard parking space information since the cim has to park near the public transport stop
 					 * (instead of parking in the vicinity of the target building).
-					 * 
+					 *
 					 * TODO we could check if the path looks like "source -> walk -> use public transport -> walk -> drive -> [walk ->] target" (in this case parking space information would still be valid)
 					*/
 #if DEBUG

--- a/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
+++ b/TLM/TLM/Manager/Impl/ExtCitizenInstanceManager.cs
@@ -37,7 +37,7 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		public void ResetInstance(ushort instanceId) {
-			ExtInstances[instanceId].Reset();
+			ExtInstances[instanceId].Reset(false);
 		}
 
 		private ExtCitizenInstanceManager() {
@@ -54,7 +54,7 @@ namespace TrafficManager.Manager.Impl {
 
 		internal void Reset() {
 			for (int i = 0; i < ExtInstances.Length; ++i) {
-				ExtInstances[i].Reset();
+				ExtInstances[i].Reset(false);
 			}
 		}
 
@@ -98,7 +98,7 @@ namespace TrafficManager.Manager.Impl {
 					if ((Singleton<CitizenManager>.instance.m_instances.m_buffer[instanceId].m_flags & CitizenInstance.Flags.Created) == CitizenInstance.Flags.None) {
 						continue;
 					}
-					
+
 					Configuration.ExtCitizenInstanceData item = new Configuration.ExtCitizenInstanceData(instanceId);
 					item.pathMode = (int)ExtInstances[instanceId].pathMode;
 					item.failedParkingAttempts = ExtInstances[instanceId].failedParkingAttempts;

--- a/TLM/TLM/Manager/Impl/SegmentEndManager.cs
+++ b/TLM/TLM/Manager/Impl/SegmentEndManager.cs
@@ -69,7 +69,7 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		public void RemoveSegmentEnd(ushort segmentId, bool startNode) {
-#if DEBUG
+#if DEBUGGEO
 			Log._Debug($"SegmentEndManager.RemoveSegmentEnd({segmentId}, {startNode}) called");
 #endif
 			DestroySegmentEnd(GetIndex(segmentId, startNode));
@@ -87,7 +87,9 @@ namespace TrafficManager.Manager.Impl {
 		public bool UpdateSegmentEnd(ushort segmentId, bool startNode) {
 			SegmentGeometry segGeo = SegmentGeometry.Get(segmentId);
 			if (segGeo == null) {
+#if DEBUGGEO
 				Log._Debug($"SegmentEndManager.UpdateSegmentEnd({segmentId}, {startNode}): Segment {segmentId} is invalid. Removing all segment ends.");
+#endif
 				RemoveSegmentEnds(segmentId);
 				return false;
 			}
@@ -113,7 +115,9 @@ namespace TrafficManager.Manager.Impl {
 					return true;
 				}
 			} else {
+#if DEBUGGEO
 				Log._Debug($"SegmentEndManager.UpdateSegmentEnd({segmentId}, {startNode}): Segment {segmentId} @ {startNode} neither has timed light nor priority sign. Removing segment end {segmentId} @ {startNode}");
+#endif
 				RemoveSegmentEnd(segmentId, startNode);
 				return false;
 			}
@@ -133,7 +137,8 @@ namespace TrafficManager.Manager.Impl {
 
 		protected void DestroySegmentEnd(int index) {
 #if DEBUG
-			Log._Debug($"SegmentEndManager.DestroySegmentEnd({index}) called");
+			if (SegmentEnds[index] != null)
+				Log._Debug($"SegmentEndManager.DestroySegmentEnd({index}) called");
 #endif
 			SegmentEnds[index]?.Destroy();
 			SegmentEnds[index] = null;

--- a/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
+++ b/TLM/TLM/Manager/Impl/TrafficPriorityManager.cs
@@ -44,7 +44,7 @@ namespace TrafficManager.Manager.Impl {
 			}
 
 			protected override void HandleInvalidNode(NodeGeometry geometry) {
-				
+
 			}
 
 			protected override void HandleValidNode(NodeGeometry geometry) {
@@ -250,7 +250,7 @@ namespace TrafficManager.Manager.Impl {
 
 		public void RemovePrioritySignsFromNode(ushort nodeId) {
 			Log._Debug($"TrafficPriorityManager.RemovePrioritySignsFromNode: nodeId={nodeId}");
-			
+
 			Services.NetService.IterateNodeSegments(nodeId, delegate(ushort segmentId, ref NetSegment segment) {
 				RemovePrioritySignFromSegmentEnd(segmentId, nodeId == segment.m_startNode);
 				return true;
@@ -258,14 +258,18 @@ namespace TrafficManager.Manager.Impl {
 		}
 
 		public void RemovePrioritySignsFromSegment(ushort segmentId) {
+#if DEBUGGEO
 			Log._Debug($"TrafficPriorityManager.RemovePrioritySignsFromSegment: segmentId={segmentId}");
+#endif
 
 			RemovePrioritySignFromSegmentEnd(segmentId, true);
 			RemovePrioritySignFromSegmentEnd(segmentId, false);
 		}
 
 		public void RemovePrioritySignFromSegmentEnd(ushort segmentId, bool startNode) {
-			Log._Debug($"TrafficPriorityManager.RemovePrioritySignFromSegment: segmentId={segmentId}, startNode={startNode}");
+#if DEBUGGEO
+			Log._Debug($"TrafficPriorityManager.RemovePrioritySignFromSegmentEnd: segmentId={segmentId}, startNode={startNode}");
+#endif
 
 			if (startNode) {
 				PrioritySegments[segmentId].startType = PriorityType.None;
@@ -345,7 +349,7 @@ namespace TrafficManager.Manager.Impl {
 #endif
 				return true;
 			}
-			
+
 			PriorityType curSign = GetPrioritySign(curPos.m_segment, startNode);
 			if (curSign == PriorityType.None) {
 #if DEBUG
@@ -640,7 +644,7 @@ namespace TrafficManager.Manager.Impl {
 			if (debug) {
 				Log._Debug("");
 				Log._Debug($"  TrafficPriorityManager.HasVehiclePriority({vehicleId}, {incomingVehicleId}): *** Checking if vehicle {vehicleId} (main road = {onMain}) @ (seg. {curPos.m_segment}, start {startNode}, lane {curPos.m_lane}) -> (seg. {nextPos.m_segment}, lane {nextPos.m_lane}) has priority over {incomingVehicleId} (main road = {incomingOnMain}) @ (seg. {incomingState.currentSegmentId}, start {incomingState.currentStartNode}, lane {incomingState.currentLaneIndex}) -> (seg. {incomingState.nextSegmentId}, lane {incomingState.nextLaneIndex}).");
-            }
+			}
 #endif
 
 			if (targetToDir == ArrowDirection.None || incomingFromDir == ArrowDirection.None || incomingToRelDir == ArrowDirection.None) {
@@ -679,7 +683,7 @@ namespace TrafficManager.Manager.Impl {
 #if DEBUG
 			if (debug) {
 				Log._Debug($"  TrafficPriorityManager.HasVehiclePriority({vehicleId}, {incomingVehicleId}): targetToDir: {targetToDir.ToString()}, incomingFromDir: {incomingFromDir.ToString()}, incomingToRelDir: {incomingToRelDir.ToString()}");
-            }
+			}
 #endif
 
 			if (Services.SimulationService.LeftHandDrive) {
@@ -1019,7 +1023,7 @@ namespace TrafficManager.Manager.Impl {
 				return ret;
 			} catch (Exception e) {
 				Log.Error($"IsLaneOrderConflictFree({segmentId}, {leftLaneIndex}, {rightLaneIndex}): Error: {e.ToString()}");
-            }
+			}
 			return true;
 		}
 

--- a/TLM/TLM/TLM.csproj
+++ b/TLM/TLM/TLM.csproj
@@ -387,6 +387,10 @@
       <Project>{D3ADE06E-F493-4819-865A-3BB44FEEDF01}</Project>
       <Name>CSUtil.Commons</Name>
     </ProjectReference>
+    <ProjectReference Include="..\CSUtil.Redirection\CSUtil.Redirection.csproj">
+      <Project>{7dcc08ef-dc85-47a4-bd6f-79fc52c7ef13}</Project>
+      <Name>CSUtil.Redirection</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TMPE.CitiesGameBridge\TMPE.CitiesGameBridge.csproj">
       <Project>{3f2f7926-5d51-4880-a2b7-4594a10d7e54}</Project>
       <Name>TMPE.CitiesGameBridge</Name>

--- a/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
@@ -235,9 +235,9 @@ namespace TrafficManager.Traffic.Data {
 			return Singleton<CitizenManager>.instance.m_instances.m_buffer[instanceId].m_citizen;
 		}
 
-		internal void Reset() {
+		internal void Reset(bool debugLog = true) {
 #if DEBUG
-			if (GlobalConfig.Instance.Debug.Switches[4]) {
+			if (debugLog && GlobalConfig.Instance.Debug.Switches[4]) {
 				Log.Warning($"Resetting ext. citizen instance {instanceId}");
 			}
 #endif

--- a/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
+++ b/TLM/TLM/Traffic/Data/ExtCitizenInstance.cs
@@ -202,7 +202,7 @@ namespace TrafficManager.Traffic.Data {
 		public float lastDistanceToParkedCar;
 
 		public override string ToString() {
-			return $"[ExtCitizenInstance\n" +
+			return $"\n[ExtCitizenInstance\n" +
 				"\t" + $"instanceId = {instanceId}\n" +
 				"\t" + $"pathMode = {pathMode}\n" +
 				"\t" + $"failedParkingAttempts = {failedParkingAttempts}\n" +
@@ -238,7 +238,7 @@ namespace TrafficManager.Traffic.Data {
 		internal void Reset(bool debugLog = true) {
 #if DEBUG
 			if (debugLog && GlobalConfig.Instance.Debug.Switches[4]) {
-				Log.Warning($"Resetting ext. citizen instance {instanceId}");
+				Log.Warning($"ExtCitizenInstance.Reset({instanceId}): Resetting ext. citizen instance {instanceId}");
 			}
 #endif
 			//Flags = ExtFlags.None;


### PR DESCRIPTION
This patch forces citizens to use their cars when going home if their car isn't near their home. It also allows them to use public transport to get to their car.
It also fixes citizens that have an abandoned car and need to use a car to go somewhere from becoming confused and staying home (if they became confused when not at home, game teleports them home, possibly abandoning their car).
Just despawning their car in these instances doesn't work as they never spawn a new car afterwards, so I've moved their parked car closer instead, except for cases where the parked car is already near their home.

An example of what this patch does:-
Before patch: Citizen drives to work, takes public transport to shops, then takes public transport home, leaving their car at work.
After patch: Citizen drives to work, takes public transport to shops, then takes public transport back to car, then drives home.
Not yet implemented: Citizen drives to work, drives to shops, then drives home.