### PR TITLE
Fix: game version 1.10.1-f2 breaks PT

### DIFF
--- a/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
+++ b/TLM/TLM/Custom/PathFinding/CustomPathFind.cs
@@ -546,6 +546,10 @@ namespace TrafficManager.Custom.PathFinding {
 			this.PathUnits.m_buffer[unit].m_length = duration;
 			this.PathUnits.m_buffer[unit].m_laneTypes = (byte)finalBufferItem.m_lanesUsed; // NON-STOCK CODE
 			this.PathUnits.m_buffer[unit].m_vehicleTypes = (ushort)finalBufferItem.m_vehiclesUsed; // NON-STOCK CODE
+
+			// Cities: Skylines uses m_speed to scale the length of lane in TransportLineAI.UpdatePath since 1.10.1-f2
+			// If we don't set this value, the scale factor will be 100 and the costs of public transport will be too high
+			this.PathUnits.m_buffer[unit].m_speed = (byte)Mathf.Clamp(finalBufferItem.m_methodDistance * 100.0f / Mathf.Max(0.01f, finalBufferItem.m_duration), 0.0f, 255.0f);
 #if DEBUG
 			/*if (_conf.Debug.Switches[4])
 				Log._Debug($"Lane/Vehicle types of path unit {unit}: {finalBufferItem.m_lanesUsed} / {finalBufferItem.m_vehiclesUsed}");*/


### PR DESCRIPTION
Hi,

I was facing the issue #186 since the July update and I decompiled the updated game program Assembly-CSharp.dll.
 
I noticed that there's a new field named `m_speed` in struct PathUnit, which is calculated in PathFind.PathFindImplementation and seems to be the average speed of a path:
`m_speed = 100 * methodDistance / duration`

Then it is used by TransportLineAI.UpdatePath to update the length of lane:
`lane.m_length = segment.m_averageLength * (100 / max(1, path.m_speed))`

`lane.m_length` is used in CustomPathFind.ProcessItemCosts to compute the cost of public transport:
```
float prevDist;
if (prevLaneType == NetInfo.LaneType.PublicTransport) {
	prevDist = netManager.m_lanes.m_buffer[item.m_laneID].m_length;
} else {
	prevDist = Mathf.Max(SEGMENT_MIN_AVERAGE_LENGTH, prevSegment.m_averageLength);
}
```

However, the new field `m_speed` is not set in our custom PathFindImplementation so it should be 0 by default. Then the value of `lane.m_length` is multiplied by 100, which makes the costs of public transport too high.

I added some code in CustomPathFind.PathFindImplementation to calculate `m_speed`. Now PT seems working fine.