### PR TITLE
Minor Changes

### DIFF
--- a/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
+++ b/TLM/TLM/Manager/Impl/JunctionRestrictionsManager.cs
@@ -255,7 +255,7 @@ namespace TrafficManager.Manager.Impl {
 			bool debug = GlobalConfig.Instance.Debug.Switches[11];
 #endif
 
-			ITurnOnRedManager turnOnRedMan = Constants.ManagerFactory.TurnOnRedManager;
+			ITurnOnRedManager turnOnRedMan = TurnOnRedManager.Instance;
 			int index = turnOnRedMan.GetIndex(segmentId, startNode);
 			bool ret =
 				(node.m_flags & NetNode.Flags.TrafficLights) != NetNode.Flags.None &&

--- a/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
+++ b/TLM/TLM/Manager/Impl/VehicleBehaviorManager.cs
@@ -307,7 +307,7 @@ namespace TrafficManager.Manager.Impl {
 					if (
 						Options.turnOnRedEnabled &&
 						stopCar &&
-						sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxYieldVelocity * GlobalConfig.Instance.PriorityRules.MaxYieldVelocity &&
+						sqrVelocity <= GlobalConfig.Instance.PriorityRules.MaxYieldVelocity &&
 						JunctionRestrictionsManager.Instance.IsTurnOnRedAllowed(prevPos.m_segment, isTargetStartNode) &&
 						!isRecklessDriver
 					) {


### PR DESCRIPTION
Changed from the InstanceManager to .Instance, to maintain consistency throughout the rest of JunctionRestrictionManager.

The yield speed felt like they were just running the red... I know most people at least hit on their brakes before turning on red, so I removed the multiplication by itself and now it feels much more natural (imo).